### PR TITLE
Fix instructions field for elderly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is an example application showing how to use the [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime) with [WebRTC](https://platform.openai.com/docs/guides/realtime-webrtc).
 
-The included demo now initializes the voice assistant with guidance aimed at
+The included demo now initializes the voice assistant with instructions aimed at
 supporting older adults. When a session starts, the model is instructed to hold
 friendly conversations that help reduce loneliness and encourage mental
 elasticity.

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -148,11 +148,11 @@ export default function App() {
       dataChannel.addEventListener("open", () => {
         setIsSessionActive(true);
         setEvents([]);
-        // Provide initial guidance for the voice assistant
+        // Provide initial instructions for the voice assistant
         sendClientEvent({
           type: "session.update",
           session: {
-            system: ELDERLY_INSTRUCTIONS,
+            instructions: ELDERLY_INSTRUCTIONS,
           },
         });
       });


### PR DESCRIPTION
## Summary
- update README to mention elderly voice assistant instructions
- switch from `system` to `instructions` when sending session.update for elderly onboarding

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6840ec38370c832ab7657aa6ae3aa621