### PR TITLE
Add voice customization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY="<your-key-here>"
+VOICE="sage"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Before you begin, you'll need an OpenAI API key - [create one in the dashboard h
 cp .env.example .env
 ```
 
+The `.env` file can also specify a default Realtime voice with the `VOICE`
+environment variable. For example:
+
+```bash
+echo "VOICE=sage" >> .env
+```
+You can override this at runtime by passing a `voice` query parameter to
+`/token`.
+
 Running this application locally requires [Node.js](https://nodejs.org/) to be installed. Install dependencies for the application with:
 
 ```bash

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import "dotenv/config";
 const app = express();
 const port = process.env.PORT || 3000;
 const apiKey = process.env.OPENAI_API_KEY;
+const defaultVoice = process.env.VOICE || "sage";
 
 // Configure Vite middleware for React client
 const vite = await createViteServer({
@@ -17,6 +18,7 @@ app.use(vite.middlewares);
 // API route for token generation
 app.get("/token", async (req, res) => {
   try {
+    const voice = req.query.voice || defaultVoice;
     const response = await fetch(
       "https://api.openai.com/v1/realtime/sessions",
       {
@@ -27,7 +29,7 @@ app.get("/token", async (req, res) => {
         },
         body: JSON.stringify({
           model: "gpt-4o-realtime-preview-2024-12-17",
-          voice: "verse",
+          voice,
         }),
       },
     );


### PR DESCRIPTION
## Summary
- make `sage` the default voice
- allow voice override via env var or query param
- document new voice option in README
- update example `.env`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840f5aa9a8c832a8716e6d74ee0c50b