### PR TITLE
Add brain exercise tool

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -8,6 +8,8 @@ const COMPANION_INSTRUCTIONS = `
   You are a friendly, proactive companion designed for older adults.
   Keep conversations lively, ask gentle questions about the user's day,
   and offer short cognitive exercises to help maintain mental elasticity.
+  You may call \`propose_brain_exercise\` whenever you need a simple
+  memory or attention task for the user.
 `;
 
 export default function App() {

--- a/client/components/ToolPanel.jsx
+++ b/client/components/ToolPanel.jsx
@@ -1,8 +1,20 @@
 import { useEffect, useState } from "react";
 
 const functionDescription = `
-Call this function when a user asks for a color palette.
+Call this function when you want to provide the user with a short brain exercise
+such as a quick memory or attention challenge.
 `;
+
+async function propose_brain_exercise() {
+  const exercises = [
+    "Memorize these three words for 30 seconds: apple, boat, tree. Then try to recall them in reverse order.",
+    "Count backwards from 100 by sevens.",
+    "Name as many animals as you can that start with the letter 'B' within one minute.",
+  ];
+
+  const exercise = exercises[Math.floor(Math.random() * exercises.length)];
+  return { exercise };
+}
 
 const sessionUpdate = {
   type: "session.update",
@@ -10,26 +22,11 @@ const sessionUpdate = {
     tools: [
       {
         type: "function",
-        name: "display_color_palette",
+        name: "propose_brain_exercise",
         description: functionDescription,
         parameters: {
           type: "object",
-          strict: true,
-          properties: {
-            theme: {
-              type: "string",
-              description: "Description of the theme for the color scheme.",
-            },
-            colors: {
-              type: "array",
-              description: "Array of five hex color codes based on the theme.",
-              items: {
-                type: "string",
-                description: "Hex color code",
-              },
-            },
-          },
-          required: ["theme", "colors"],
+          properties: {},
         },
       },
     ],
@@ -37,27 +34,13 @@ const sessionUpdate = {
   },
 };
 
-function FunctionCallOutput({ functionCallOutput }) {
-  const { theme, colors } = JSON.parse(functionCallOutput.arguments);
-
-  const colorBoxes = colors.map((color) => (
-    <div
-      key={color}
-      className="w-full h-16 rounded-md flex items-center justify-center border border-gray-200"
-      style={{ backgroundColor: color }}
-    >
-      <p className="text-sm font-bold text-black bg-slate-100 rounded-md p-2 border border-black">
-        {color}
-      </p>
-    </div>
-  ));
-
+function ExerciseOutput({ result }) {
   return (
     <div className="flex flex-col gap-2">
-      <p>Theme: {theme}</p>
-      {colorBoxes}
+      <p className="font-semibold">Brain Exercise:</p>
+      <p>{result.exercise}</p>
       <pre className="text-xs bg-gray-100 rounded-md p-2 overflow-x-auto">
-        {JSON.stringify(functionCallOutput, null, 2)}
+        {JSON.stringify(result, null, 2)}
       </pre>
     </div>
   );
@@ -69,7 +52,7 @@ export default function ToolPanel({
   events,
 }) {
   const [functionAdded, setFunctionAdded] = useState(false);
-  const [functionCallOutput, setFunctionCallOutput] = useState(null);
+  const [exerciseResult, setExerciseResult] = useState(null);
 
   useEffect(() => {
     if (!events || events.length === 0) return;
@@ -85,20 +68,18 @@ export default function ToolPanel({
       mostRecentEvent.type === "response.done" &&
       mostRecentEvent.response.output
     ) {
-      mostRecentEvent.response.output.forEach((output) => {
+      mostRecentEvent.response.output.forEach(async (output) => {
         if (
           output.type === "function_call" &&
-          output.name === "display_color_palette"
+          output.name === "propose_brain_exercise"
         ) {
-          setFunctionCallOutput(output);
+          const result = await propose_brain_exercise();
+          setExerciseResult(result);
           setTimeout(() => {
             sendClientEvent({
               type: "response.create",
               response: {
-                instructions: `
-                ask for feedback about the color palette - don't repeat 
-                the colors, just ask if they like the colors.
-              `,
+                instructions: `share the exercise with the user and encourage them to try it.`,
               },
             });
           }, 500);
@@ -110,19 +91,19 @@ export default function ToolPanel({
   useEffect(() => {
     if (!isSessionActive) {
       setFunctionAdded(false);
-      setFunctionCallOutput(null);
+      setExerciseResult(null);
     }
   }, [isSessionActive]);
 
   return (
     <section className="h-full w-full flex flex-col gap-4">
       <div className="h-full bg-gray-50 rounded-md p-4">
-        <h2 className="text-lg font-bold">Color Palette Tool</h2>
+        <h2 className="text-lg font-bold">Brain Exercise Tool</h2>
         {isSessionActive ? (
-          functionCallOutput ? (
-            <FunctionCallOutput functionCallOutput={functionCallOutput} />
+          exerciseResult ? (
+            <ExerciseOutput result={exerciseResult} />
           ) : (
-            <p>Ask for advice on a color palette...</p>
+            <p>Ask for a short brain exercise...</p>
           )
         ) : (
           <p>Start the session to use this tool...</p>


### PR DESCRIPTION
## Summary
- replace color palette function with a new `propose_brain_exercise` tool
- allow the model to call this function to get a simple mental exercise
- inform the model about the new tool in session instructions
- show the generated exercise in the side panel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840f608c334832a9a2c59aa24bdca06