### PR TITLE
Add persistent conversation data example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+user-data.json

--- a/server.js
+++ b/server.js
@@ -8,12 +8,48 @@ const port = process.env.PORT || 3000;
 const apiKey = process.env.OPENAI_API_KEY;
 const defaultVoice = process.env.VOICE || "sage";
 
+app.use(express.json());
+
+// simple persistent store for conversation summaries
+const DATA_FILE = "./user-data.json";
+let userData = { summaries: [] };
+try {
+  if (fs.existsSync(DATA_FILE)) {
+    userData = JSON.parse(fs.readFileSync(DATA_FILE, "utf-8"));
+  }
+} catch (e) {
+  console.error("Failed to load user data", e);
+}
+
+function saveUserData() {
+  try {
+    fs.writeFileSync(DATA_FILE, JSON.stringify(userData, null, 2));
+  } catch (e) {
+    console.error("Failed to save user data", e);
+  }
+}
+
 // Configure Vite middleware for React client
 const vite = await createViteServer({
   server: { middlewareMode: true },
   appType: "custom",
 });
 app.use(vite.middlewares);
+
+// expose persisted user data
+app.get("/userdata", (req, res) => {
+  res.json(userData);
+});
+
+app.post("/userdata", (req, res) => {
+  const { summary } = req.body;
+  if (!summary) {
+    return res.status(400).json({ error: "No summary provided" });
+  }
+  userData.summaries.push({ summary, timestamp: new Date().toISOString() });
+  saveUserData();
+  res.status(201).json({ ok: true });
+});
 
 // API route for token generation
 app.get("/token", async (req, res) => {


### PR DESCRIPTION
## Summary
- persist conversation summaries on the server
- expose `/userdata` API for retrieving and adding summaries
- fetch stored summaries in React client and send them with `session.update`
- store a short summary of each session when it ends
- ignore generated `user-data.json`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68421a017314832aacb94e457ecbcdff